### PR TITLE
Updating project settings so that Simulator builds will compile on Apple Silicon.

### DIFF
--- a/ios/xcode/OpenGLES.xcodeproj/project.pbxproj
+++ b/ios/xcode/OpenGLES.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -12520,6 +12520,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_CPP_RTTI = NO;
@@ -12609,6 +12610,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_ENABLE_CPP_RTTI = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -12649,6 +12651,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = "-Wno-shorten-64-to-32";
 				SDKROOT = iphoneos;
 				TVOS_DEPLOYMENT_TARGET = 9.0;


### PR DESCRIPTION
Updating project settings so that Simulator builds will compile on Apple Silicon.

See conversation in https://github.com/mindsnacks/CoreMS/pull/1280 for details.  💬  Basically, we're trying to get `mindsnacks/master` to match the exact commit that we had it on from https://github.com/kakashidinho/metalangle without pulling in any unintended new commits from the upstream. 🐟  And then this PR is adding the changes to the Xcode project settings on top of that commit. 🔝